### PR TITLE
新增首頁可指定 Tab 與內容頁顯示錯誤問題

### DIFF
--- a/Web/Script/Loader.js
+++ b/Web/Script/Loader.js
@@ -198,10 +198,19 @@ function data() {
 function Init() {
     //Tab Selected
     var name = $.url.param("tab");
-	var tab = $(".Tag:contains('" + name + "')");
+    var tab = $(".Tag:contains('" + name + "')");
+
     if ("" == name || 0 == $(tab).length) {
 		tab = $(".Tag:contains('" + $(".Tab").attr("data-selected") + "')");
-	}
+    }
+
+    var parentText = $(tab).parent().attr("tag");
+    var parentTab = $(".Tag:contains('" + parentText + "')")
+
+    // Have upper level tab
+    if (parentText != undefined || $(parentTab).length == 1) {
+        $(parentTab).click()
+    }
     $(tab).click();
 }
 

--- a/Web/Script/Plugin/jquery.Fill.js
+++ b/Web/Script/Plugin/jquery.Fill.js
@@ -78,7 +78,11 @@
             function wove(host, data) {
                 var table = $("<table/>", { "class": "Wove" });
                 $(data).find("Item").each(function () {
-                    $("<tr/>", { href: _settings.basePath + "Page/" + $(this).attr("href") + ".php" })
+                    var url = _settings.basePath + "Page/" + $(this).attr("href") + ".php"
+                    if ($(this).attr("tab") != undefined) {
+                        url = url + "?tab=" + $(this).attr("tab")
+                    }
+                    $("<tr/>", { href: url})
                         .append($("<td/>", { "class": "Bullet" }).append($("<img/>", { src: _settings.basePath + "Image/Basis/Bullet.png" })))
                         .append($("<td/>", { "class": "Name", text: $(this).attr("name") }))
                         .append($("<td/>", { "class": "Date", text: $(this).attr("date") }))


### PR DESCRIPTION
## 修正內容頁 Tab 顯示問題

原先內容頁可用如 `.../C310.php?tab=側掛` 的方式指定，但是顯示時會出現如下圖的狀況，修正後應能正常顯示

![顯示問題](https://user-images.githubusercontent.com/6011839/58730955-1c4ae100-8420-11e9-855a-d61a4dc2116c.JPG)


## 首頁可指定連結的 Tab

過去不論任何專長課的連結進去都只會到 **深潛專長**，更新後在每一項的裡面加上 `tab="[課程名稱]"`就可以指定目標 Tab（課程名稱以 Tab 的值為主）

```
# /Data/Default.CH.xml
<Item name="高氧專長-02期" date="05-03" type="Blue" text="可報名" href="C310" tab="高氧" />
<Item name="正確反應員-01期" date="05-13" type="Blue" text="可報名" href="C310" tab="正確反應員" />
<Item name="環境保護員-02期" date="08-02" type="Blue" text="可報名" href="C310" tab="ECO DIVER" />
```
